### PR TITLE
Support Fahrenheit and user-provided I2C Wire object

### DIFF
--- a/Adafruit_ADT7410.cpp
+++ b/Adafruit_ADT7410.cpp
@@ -8,7 +8,7 @@
  * 	I2C Driver for Microchip's ADT7410 I2C Temp sensor
  *
  * 	This is a library for the Adafruit ADT7410 breakout:
- * 	http://www.adafruit.com/products/1782
+ * 	http://www.adafruit.com/products/4089
  *
  * 	Adafruit invests time and resources providing this open source code,
  *  please support Adafruit and open-source hardware by purchasing products from
@@ -71,6 +71,20 @@ float Adafruit_ADT7410::readTempC() {
 
   float temp = (int16_t)t;
   temp /= 128.0;
+
+  return temp;
+}
+
+/*!
+ *   @brief  Reads the 16-bit temperature register and returns the Fahrenheit
+ *           temperature as a float.
+ *   @return Temperature in Fahrenheit.
+ */
+float Adafruit_ADT7410::readTempF() {
+  uint16_t t = read16(ADT7410_REG__ADT7410_TEMPMSB);
+
+  float temp = (int16_t)t;
+  temp = temp * 0.0140625 /*( 1.0/128.0 * 9.0/5.0 )*/ + 32.0;
 
   return temp;
 }

--- a/Adafruit_ADT7410.cpp
+++ b/Adafruit_ADT7410.cpp
@@ -49,7 +49,7 @@ bool Adafruit_ADT7410::begin() {
 
 /*!
  *    @brief  Setups the HW with default address
- *    @param  *theWire
+ *    @param  *wire
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_ADT7410::begin(TwoWire *wire) {
@@ -72,7 +72,7 @@ bool Adafruit_ADT7410::begin(uint8_t addr) {
 /*!
  *    @brief  Setups the HW
  *    @param  addr
- *    @param  *theWire
+ *    @param  *wire
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_ADT7410::begin(uint8_t addr, TwoWire *wire) {

--- a/Adafruit_ADT7410.h
+++ b/Adafruit_ADT7410.h
@@ -4,10 +4,10 @@
  * 	I2C Driver for Microchip's ADT7410 I2C Temp sensor
  *
  * 	This is a library for the Adafruit ADT7410 breakout:
- * 	http://www.adafruit.com/products/xxxx
+ * 	http://www.adafruit.com/products/4089
  *
  * 	Adafruit invests time and resources providing this open source code,
- *please support Adafruit and open-source hardware by purchasing products from
+ *  please support Adafruit and open-source hardware by purchasing products from
  * 	Adafruit!
  *
  *
@@ -39,6 +39,7 @@ public:
   Adafruit_ADT7410();
   boolean begin(uint8_t a = ADT7410_I2CADDR_DEFAULT);
   float readTempC();
+  float readTempF();
   void write8(uint8_t reg, uint8_t val);
   uint16_t read16(uint8_t reg);
   uint8_t read8(uint8_t reg);

--- a/Adafruit_ADT7410.h
+++ b/Adafruit_ADT7410.h
@@ -37,14 +37,22 @@
 class Adafruit_ADT7410 {
 public:
   Adafruit_ADT7410();
-  boolean begin(uint8_t a = ADT7410_I2CADDR_DEFAULT);
+  bool begin();
+  bool begin(TwoWire *theWire);
+  bool begin(uint8_t addr);
+  bool begin(uint8_t addr, TwoWire *theWire);
+
+  bool init();
   float readTempC();
   float readTempF();
+
+  uint8_t read8(uint8_t reg);
   void write8(uint8_t reg, uint8_t val);
   uint16_t read16(uint8_t reg);
-  uint8_t read8(uint8_t reg);
+  void write16(uint8_t reg, uint16_t val);
 
 private:
+  TwoWire *_wire;
   uint8_t _i2caddr;
 };
 


### PR DESCRIPTION
- **Describe the scope of your change**
Two compatibility updates so that this library is (almost) a drop-in replacement with Adafruit_MCP9808_Library, but doesn't break existing functionality or interfaces:

    1. Added a Fahrenheit conversion interface
    2. Added support for a user-provided I2C Wire object

- **Describe any known limitations with your change.**
The MCP9808 library lets the user specify the ADC resolution. The datasheet of the ADT7410 also defines this capability, but it isn't currently implemented. The higher-resolution 16-bit conversion is always used. For some reason the previous code didn't explicitly set this, even though the Celsius calculation apparently expected it. Added code to explicitly set it.

- **Please run any tests or examples that can exercise your modified code.**
Using the latest unmodified PyPortal self-test (https://github.com/adafruit/Adafruit_Learning_System_Guides/blob/master/PyPortal_ArduinoSelfTest/PyPortal_ArduinoSelfTest.ino) as a test case, the Celsius output remained as expected. Adding a Fahrenheit output to that demo also displayed correctly.

