### PR TITLE
Correct number of bytes to read in read8().

### DIFF
--- a/Adafruit_ADT7410.cpp
+++ b/Adafruit_ADT7410.cpp
@@ -116,6 +116,6 @@ uint8_t Adafruit_ADT7410::read8(uint8_t reg) {
   Wire.write((uint8_t)reg);
   Wire.endTransmission(false);
 
-  Wire.requestFrom((uint8_t)_i2caddr, (uint8_t)2);
+  Wire.requestFrom((uint8_t)_i2caddr, (uint8_t)1);
   return Wire.read();
 }


### PR DESCRIPTION
Correcting the number of bytes to read in the read8() method.  On the mbed based Arduinos (e.g Nano 33 BLE) it is necessary to specify the expected number of bytes as the mbed based I2C methods do not flush the receive buffer between each call.  Thus if specifying 2 bytes when only 1 is expected you end up with garbage after the first read from the sensor. (The original worked fine on AVR and SAMD21 boards as there is an explicit flush of the receive buffer in the wire library.)

Tested the included example with this change on Arduino Uno, Arduino Nano 33 IoT, and Arduino Nano 33 BLE Sense.
