### PR TITLE
Add support for setting ADC resolution

### DIFF
--- a/Adafruit_ADT7410.cpp
+++ b/Adafruit_ADT7410.cpp
@@ -143,3 +143,35 @@ bool Adafruit_ADT7410::getEvent(sensors_event_t *event) {
 
   return true;
 }
+
+/**************************************************************************/
+/*!
+    @brief  Gets the current ADC resolution setting.
+    @returns The current ADC resolution setting.
+*/
+/**************************************************************************/
+adt7410Resolution Adafruit_ADT7410::getResolution() {
+  Adafruit_BusIO_Register config_reg =
+      Adafruit_BusIO_Register(i2c_dev, ADT7410_REG__ADT7410_CONFIG);
+  Adafruit_BusIO_RegisterBits resolution =
+      Adafruit_BusIO_RegisterBits(&config_reg, 1, 0);
+
+  return (adt7410Resolution)resolution.read();
+}
+
+/**************************************************************************/
+/*!
+    @brief  Sets the current ADC resolution setting.
+    @param  res The ADC resolution to set, either ADT7410_13BIT or
+   ADT7410_16BIT.
+    @returns True on successful write otherwise false
+*/
+/**************************************************************************/
+bool Adafruit_ADT7410::setResolution(adt7410Resolution res) {
+  Adafruit_BusIO_Register config_reg =
+      Adafruit_BusIO_Register(i2c_dev, ADT7410_REG__ADT7410_CONFIG);
+  Adafruit_BusIO_RegisterBits resolution =
+      Adafruit_BusIO_RegisterBits(&config_reg, 1, 0);
+
+  return resolution.write(res & 0x01);
+}

--- a/Adafruit_ADT7410.h
+++ b/Adafruit_ADT7410.h
@@ -31,6 +31,9 @@
 #define ADT7410_REG__ADT7410_ID 0xB      ///< Manufacturer identification
 #define ADT7410_REG__ADT7410_SWRST 0x2F  ///< Temperature hysteresis
 
+/** Options for resolution */
+typedef enum { ADT7410_13BIT = 0, ADT7410_16BIT } adt7410Resolution;
+
 /*!
  *    @brief  Class that stores state and functions for interacting with
  *            ADT7410 Temp Sensor
@@ -44,6 +47,8 @@ public:
 
   bool getEvent(sensors_event_t *event);
   void getSensor(sensor_t *sensor);
+  adt7410Resolution getResolution();
+  bool setResolution(adt7410Resolution res);
 
 private:
   int32_t _sensorID = 7410;

--- a/examples/adt7410test/adt7410test.ino
+++ b/examples/adt7410test/adt7410test.ino
@@ -18,7 +18,7 @@ Adafruit_ADT7410 tempsensor = Adafruit_ADT7410();
 void setup() {
   Serial.begin(115200);
   Serial.println("ADT7410 demo");
-  
+
   // Make sure the sensor is found, you can also pass in a different i2c
   // address with tempsensor.begin(0x49) for example
   if (!tempsensor.begin()) {
@@ -28,14 +28,32 @@ void setup() {
 
   // sensor takes 250 ms to get first readings
   delay(250);
+
+  // ** Optional **
+  // Can set ADC resolution
+  // ADT7410_13BIT = 13 bits (default)
+  // ADT7410_16BIT = 16 bits
+  tempsensor.setResolution(ADT7410_16BIT);
+  Serial.print("Resolution = ");
+  switch (tempsensor.getResolution()) {
+    case ADT7410_13BIT:
+      Serial.print("13 ");
+      break;
+    case ADT7410_16BIT:
+      Serial.print("16 ");
+      break;
+    default:
+      Serial.print("??");
+  }
+  Serial.println("bits");
 }
 
 void loop() {
   // Read and print out the temperature, then convert to *F
   float c = tempsensor.readTempC();
   float f = c * 9.0 / 5.0 + 32;
-  Serial.print("Temp: "); Serial.print(c); Serial.print("*C\t"); 
+  Serial.print("Temp: "); Serial.print(c); Serial.print("*C\t");
   Serial.print(f); Serial.println("*F");
-  
+
   delay(1000);
 }


### PR DESCRIPTION
For #12.

Adds getter/setter for ADC resolution via bit 7 of config register:
![image](https://github.com/adafruit/Adafruit_ADT7410/assets/8755041/6e55e392-f377-4e5e-b2e2-c7b435b03dc9)

Example updated to show usage.

Output in **16 bit mode**:
![Screenshot from 2023-11-30 12-57-56](https://github.com/adafruit/Adafruit_ADT7410/assets/8755041/21ade993-c18e-44d5-b5bf-c8563e9312f6)


Output in **13 bit mode**:
![Screenshot from 2023-11-30 13-01-22](https://github.com/adafruit/Adafruit_ADT7410/assets/8755041/929dfcba-f51b-4398-8c3e-d67ed4bf84c8)
